### PR TITLE
4.2.2

### DIFF
--- a/pro-features/advanced-table.php
+++ b/pro-features/advanced-table.php
@@ -147,8 +147,8 @@ function ws_ls_advanced_data_table($weight_data)
 
 		$html_output .= '	<td style="font-size:0.7em;word-wrap:break-word;">' . $weight_object['notes'] . '</td>
 							<td class="ws-ls-table-options">
-								<img  src="' . $edit_image .'"  id="ws-ls-edit-' . $weight_object['db_row_id'] . '" data-row-id="' . $weight_object['db_row_id'] . '" class="first ws-ls-edit-row" />
-								<img src="' . $delete_image .'"  id="ws-ls-delete-' . $weight_object['db_row_id'] . '" data-row-id="' . $weight_object['db_row_id'] . '" class="ws-ls-delete-row" />
+								<img width="15" height="15" style="width:15px; height: 15px;" src="' . $edit_image .'"  id="ws-ls-edit-' . $weight_object['db_row_id'] . '" data-row-id="' . $weight_object['db_row_id'] . '" class="first ws-ls-edit-row" />
+								<img width="15" height="15" style="width:15px; height: 15px;" src="' . $delete_image .'"  id="ws-ls-delete-' . $weight_object['db_row_id'] . '" data-row-id="' . $weight_object['db_row_id'] . '" class="ws-ls-delete-row" />
 							</td>
 						</tr>';
   }

--- a/pro-features/emails.php
+++ b/pro-features/emails.php
@@ -85,7 +85,7 @@ function ws_ls_email_notifications_template($placeholders = array()) {
 
 function ws_ls_email_notification_addresses() {
 
-	if(empty(WE_LS_EMAIL_ADDRESSES)) {
+	if(!defined('WE_LS_EMAIL_ADDRESSES')) {
 		return false;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight, loss, lose, helper, bmi, body, mass, index, graph, track, stones, kg, table, data, plot, target, history, pounds, responsive, chart, measurements, cm, centimeters, inches, hip, waist, bicep, thigh
 Requires at least: 4.1.0
 Tested up to: 4.7.2
-Stable tag: 4.2.1
+Stable tag: 4.2.2
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -155,6 +155,11 @@ Yes. In WordPress Admin goto Settings > Weight Loss Tracker and change the setti
 Lots of new features. Three new Pro shortcodes, email notifications and more.
 
 == Changelog ==
+
+= 4.2.2 =
+
+Bug fix: Fixed super large / delete icons in advanced table (probably due to cached CSS more than anything).
+Bug fix: Use defined() instead of empty() to check for a empty constant.
 
 = 4.2.1 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name: Weight Loss Tracker
  * Description: Allow registered users of your website to track their weight and relevant body measurements. History can be displayed in both tables & charts.
- * Version: 4.2.1
+ * Version: 4.2.2
 
  * Author: YeKen
  * Author URI: https://www.YeKen.uk
@@ -29,7 +29,7 @@ defined('ABSPATH') or die('Jog on!');
 */
 
 define('WS_LS_ABSPATH', plugin_dir_path( __FILE__ ));
-define('WE_LS_CURRENT_VERSION', '4.2.1');
+define('WE_LS_CURRENT_VERSION', '4.2.2');
 
 // -----------------------------------------------------------------------------------------
 // AC: Activate / Deactivate / Uninstall Hooks


### PR DESCRIPTION
Bug fix: Fixed super large / delete icons in advanced table (probably due to cached CSS more than anything).
Bug fix: Use defined() instead of empty() to check for a empty constant.