### PR TITLE
4.2.7

### DIFF
--- a/includes/activate.php
+++ b/includes/activate.php
@@ -21,7 +21,7 @@
 
 		// Remove cron jobs
 		wp_clear_scheduled_hook( WE_LS_CRON_NAME );
-		wp_clear_scheduled_hook( WE_LS_CRON_NAME );
+		wp_clear_scheduled_hook( WE_LS_CRON_NAME_YEKEN_COMMS );
 	}
 
 	function ws_ls_create_mysql_tables()
@@ -55,6 +55,7 @@
 			left_forearm float NULL,
 			right_forearm float NULL,
 			shoulders float NULL,
+			neck float NULL,
 		  UNIQUE KEY id (id)
 		) $charset_collate;";
 

--- a/includes/caching.php
+++ b/includes/caching.php
@@ -34,6 +34,9 @@ function ws_ls_delete_cache($key){
 }
 function ws_ls_delete_cache_for_given_user($user_id = false)
 {
+
+	//TODO: Rewrite caching to use group keys
+
   global $wpdb;
 
   if (WE_LS_CACHE_ENABLED){
@@ -49,12 +52,23 @@ function ws_ls_delete_cache_for_given_user($user_id = false)
     $sql = "Delete FROM  $wpdb->options
             WHERE option_name LIKE '%transient_timeout_" . WE_LS_SLUG . $user_id ."%'";
 
-    ws_ls_delete_cache($user_id . '-' . WE_LS_CACHE_KEY_START_WEIGHT);
-	ws_ls_delete_cache($user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_FOR_DAY);
-	ws_ls_delete_cache($user_id . '-' . WE_LS_CACHE_KEY_TARGET_WEIGHT . 'target_weight_only_pounds');
-	ws_ls_delete_cache($user_id . '-' . WE_LS_CACHE_KEY_TARGET_WEIGHT . 'target_weight_weight');
+	$wpdb->query($sql);
 
-    $wpdb->query($sql);
+	$keys_to_clear = array(
+							$user_id . '-' . WE_LS_CACHE_KEY_START_WEIGHT,
+							$user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_FOR_DAY,
+							$user_id . '-' . WE_LS_CACHE_KEY_TARGET_WEIGHT . 'target_weight_weight',
+							$user_id . '-' . WE_LS_CACHE_KEY_TARGET_WEIGHT . 'target_weight_only_pounds',
+							$user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_EXTREME . '-asc-weight_only_pounds',
+	 						$user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_EXTREME . '-desc-weight_only_pounds',
+							$user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_EXTREME . '-asc-weight_weight',
+							$user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_EXTREME . '-desc-weight_weight'
+						);
+
+	foreach ($keys_to_clear as $key) {
+		ws_ls_delete_cache($key);
+	}
+
   }
 }
 function ws_ls_delete_all_cache()

--- a/includes/core.php
+++ b/includes/core.php
@@ -46,7 +46,8 @@
 			'show-gridlines' => WE_LS_CHART_SHOW_GRID_LINES,
 			'bezier' => WE_LS_CHART_BEZIER_CURVE,
             'hide_login_message_if_needed' => true,
-			'exclude-measurements' => false
+			'exclude-measurements' => false,
+			'ignore-login-status' => false
 		);
 
         // If we are PRO and the developer has specified options then override the default
@@ -56,9 +57,9 @@
 
 		$measurements_enabled = (false == $chart_config['exclude-measurements'] && WE_LS_MEASUREMENTS_ENABLED && ws_ls_any_active_measurement_fields()) ? true : false;
 
-        // Make sure they are logged in
-        if (!is_user_logged_in())	{
-            if ($chart_config['hide_login_message_if_needed']) {
+		// Make sure they are logged in
+        if (false == $chart_config['ignore-login-status'] && !is_user_logged_in())	{
+            if (false == $chart_config['hide_login_message_if_needed']) {
                 return '<blockquote class="ws-ls-blockquote"><p>' .	__('You need to be logged in to record your weight.', WE_LS_SLUG) . ' <a href="' . wp_login_url(get_permalink()) . '">' . __('Login now', WE_LS_SLUG) . '</a>.</p></blockquote>';
             } else {
                 return;

--- a/includes/db.php
+++ b/includes/db.php
@@ -432,7 +432,7 @@ function ws_ls_get_user_preferences($user_id = false, $use_cache = true)
   $cache = ws_ls_get_cache($cache_key);
 
   // Return cache if found!
-  if ($cache && true == $use_cache)   {
+  if (is_array($cache) && true == $use_cache)   {
       return $cache;
   }
 
@@ -449,9 +449,7 @@ function ws_ls_get_user_preferences($user_id = false, $use_cache = true)
     $settings = array();
   }
 
-  if($settings !== false) {
-	  ws_ls_set_cache($cache_key, $settings);
-  }
+  ws_ls_set_cache($cache_key, $settings);
 
   return $settings;
 }

--- a/includes/globals.php
+++ b/includes/globals.php
@@ -43,11 +43,14 @@
 	// Hooks / Filters
 	// -----------------------------------------------------------------------------------
 
-	define('WE_LS_HOOK_DATA_ADDED_EDITED', 'ws-ls-data-added-edited');
-	define('WE_LS_HOOK_DATA_ALL_DELETED', 'ws-ls-data-all-deleted');
-	define('WE_LS_HOOK_DATA_USER_DELETED', 'ws-ls-data-use-deleted');
+	define('WE_LS_HOOK_DATA_ADDED_EDITED', 'wlt-hook-data-added-edited');
+	define('WE_LS_HOOK_DATA_ALL_DELETED', 'wlt-hook-data-all-deleted');
+	define('WE_LS_HOOK_DATA_USER_DELETED', 'wlt-hook-data-user-deleted');
 
-	define('WE_LS_FILTER_EMAIL_DATA', 'ws-ls-filter-email-data');
+	define('WE_LS_FILTER_EMAIL_DATA', 'wlt-filter-email-data');
+	define('WE_LS_FILTER_STATS_SHORTCODE', 'wlt-filter-stats-shortcode');
+	define('WE_LS_FILTER_STATS_ROW', 'wlt-filter-stats-table-row');
+	define('WE_LS_FILTER_STATS_TABLE_HTML', 'wlt-filter-stats-table-html');
 
     // -----------------------------------------------------------------------------------
 	// Dynamic Settings based upon user settings, etc
@@ -113,8 +116,8 @@
 		'height' => array('title' => __('Height', WE_LS_SLUG), 'enabled' => true, 'user_preference' => true),
         'buttocks' => array('title' => __('Buttocks', WE_LS_SLUG), 'user_preference' => false, 'enabled' => false, 'chart_colour' => '#240d1d'),
         'hips' => array('title' => __('Hips', WE_LS_SLUG), 'user_preference' => false, 'enabled' => false, 'chart_colour' => '#35e364'),
-        'navel' => array('title' => __('Navel', WE_LS_SLUG), 'user_preference' => false, 'enabled' => false, 'chart_colour' => '#a28c87')
-
+        'navel' => array('title' => __('Navel', WE_LS_SLUG), 'user_preference' => false, 'enabled' => false, 'chart_colour' => '#a28c87'),
+		'neck' => array('title' => __('Neck', WE_LS_SLUG), 'user_preference' => false, 'enabled' => false, 'chart_colour' => '#FA8072')
     );
 
     $globals['WE_LS_MEASUREMENTS'] = json_encode($supported_measurements);

--- a/includes/shortcode-various.php
+++ b/includes/shortcode-various.php
@@ -127,12 +127,11 @@ function ws_ls_get_weight_extreme($user_id, $recent = false, $unit = "weight_wei
 	if ($recent)
 		$direction = "desc";
 
-	$cache_key = $user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_EXTREME . '-' . $direction;
-	$cache = ws_ls_get_cache($cache_key);
+	$cache_key = $user_id . '-' . WE_LS_CACHE_KEY_WEIGHT_EXTREME . '-' . $direction . '-' . $unit;
 
 	// Return cache if found!
-	if ($cache)   {
-			return $cache;
+	if ($cache = ws_ls_get_cache($cache_key))   {
+		return $cache;
 	}
 
 	$table_name = $wpdb->prefix . WE_LS_TABLENAME;

--- a/pro-features/init.php
+++ b/pro-features/init.php
@@ -44,7 +44,8 @@ function ws_ls_register_pro_shortcodes(){
 		[wlt-league-table] - Show a league table of weight loss users.
 		[wlt-reminder] - Show a reminder to either enter weight for today or target weight
 		[wlt-progress-bar] - Show a progress bar indicating progress towards target weight.
-		[wlt-message] - Show a message if the user meets certain criteria (e.g. put weight on)
+		[wlt-message] - Show a message if the user meets certain criteria (e.g. put weight on).
+		[wlt-user-settings] - Shows a form for user settings.
     */
 
     add_shortcode( 'weight-loss-tracker-chart', 'ws_ls_shortcode_chart' );
@@ -65,6 +66,8 @@ function ws_ls_register_pro_shortcodes(){
 	add_shortcode( 'wlt-progress-bar', 'ws_ls_shortcode_progress_bar' );
 	add_shortcode( 'weight-loss-tracker-message', 'ws_ls_shortcode_message' );
 	add_shortcode( 'wlt-message', 'ws_ls_shortcode_message' );
+	add_shortcode( 'wlt-user-settings', 'ws_ls_user_preferences_form' );
+
 }
 add_action( 'init', 'ws_ls_register_pro_shortcodes');
 

--- a/pro-features/shortcode-chart.php
+++ b/pro-features/shortcode-chart.php
@@ -23,13 +23,15 @@ function ws_ls_shortcode_chart($user_defined_arguments)
             'weight-target-color' => WE_LS_TARGET_LINE_COLOUR,
             'show-gridlines' => WE_LS_CHART_SHOW_GRID_LINES,
             'bezier' => WE_LS_CHART_BEZIER_CURVE,
-			'exclude-measurements' => false
+			'exclude-measurements' => false,
+			'ignore-login-status' => false
            ), $user_defined_arguments );
 
     // Tidy up a few configs
     $chart_arguments['bezier'] = ws_ls_force_bool_argument($chart_arguments['bezier']);
     $chart_arguments['show-gridlines'] = ws_ls_force_bool_argument($chart_arguments['show-gridlines']);
 	$chart_arguments['exclude-measurements'] = ws_ls_force_bool_argument($chart_arguments['exclude-measurements']);
+	$chart_arguments['ignore-login-status'] = ws_ls_force_bool_argument($chart_arguments['ignore-login-status']);
 
     // Validate height
     if (!is_numeric($chart_arguments['height']) || $chart_arguments['height'] < 50) {

--- a/pro-features/shortcode-stats.php
+++ b/pro-features/shortcode-stats.php
@@ -47,7 +47,7 @@ function ws_ls_shortcode_stats_league_total($user_defined_arguments)
 		foreach ($data as $row) {
 
 			// Allow others to manipulate this data
-			$row = apply_filters('weight-loss-stats-table-row', $row);
+			$row = apply_filters(WE_LS_FILTER_STATS_ROW, $row);
 
 			// Display name from WP
 			$user_info = get_userdata($row['user_id']);
@@ -90,7 +90,7 @@ function ws_ls_shortcode_stats_league_total($user_defined_arguments)
 				</table>';
 
 		// Allow others to manipulate this html
-		return apply_filters('weight-loss-stats-table-html', $html);
+		return apply_filters(WE_LS_FILTER_STATS_TABLE_HTML, $html);
 	}
 
 	return __('No users have entered weights.', WE_LS_SLUG) .'<!-- Issue loading Weight Loss table (No data) -->';
@@ -154,7 +154,7 @@ function ws_ls_shortcode_stats_display_value($stats, $arguments) {
 		}
 
 		// Allow theme developer to override stats message
-		$stats = apply_filters('ws-ls-stats-shortcode', $stats);
+		$stats = apply_filters(WE_LS_FILTER_STATS_SHORTCODE, $stats);
 
 		return $stats;
 	}

--- a/pro-features/widget-form.php
+++ b/pro-features/widget-form.php
@@ -14,10 +14,11 @@ class ws_ls_widget_form extends WP_Widget {
 		);
 
         $this->field_values = array(
-            'title' => __('Your weight today', WE_LS_SLUG),
-						'force_todays_date' => 'yes',
-                        'not-logged-in-message' => '',
-						'exclude-measurements' => 'no'
+            							'title' => __('Your weight today', WE_LS_SLUG),
+										'force_todays_date' => 'yes',
+				                        'not-logged-in-message' => '',
+										'exclude-measurements' => 'no',
+										'redirect-url' => ''
         );
 
 	}
@@ -41,7 +42,8 @@ class ws_ls_widget_form extends WP_Widget {
 			echo $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ). $args['after_title'];
 			$force_to_todays_date = ('yes' == $instance['force_todays_date']) ? true : false;
 			$exclude_measurements = (!empty($instance['exclude-measurements']) && 'yes' == $instance['exclude-measurements']) ? true : false;
-			echo ws_ls_display_weight_form(false, false, false, true, ws_ls_remove_non_numeric($args['widget_id']) + 10000, $force_to_todays_date, true, $exclude_measurements);
+			$redirect_url = (!empty($instance['redirect-url'])) ? $instance['redirect-url']  : '';
+			echo ws_ls_display_weight_form(false, false, false, true, ws_ls_remove_non_numeric($args['widget_id']) + 10000, $force_to_todays_date, true, $exclude_measurements, $redirect_url);
             echo $args['after_widget'];
         } elseif (isset($instance['not-logged-in-message']) && !empty($instance['not-logged-in-message'])) {
             echo $args['before_widget'];
@@ -90,8 +92,11 @@ class ws_ls_widget_form extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'not-logged-in-message' ); ?>"><?php _e('Message to display if not logged in', WE_LS_SLUG); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'not-logged-in-message' ); ?>" name="<?php echo $this->get_field_name( 'not-logged-in-message' ); ?>" type="text" value="<?php echo esc_attr( $field_values['not-logged-in-message'] ); ?>">
 		   <p><small><?php _e('By default the widget is hidden if the user is not logged in. If you wish, you can display a message to the visitor instead.', WE_LS_SLUG); ?></small></p>
-
-        <!--</p>-->
+		<p>
+			<label for="<?php echo $this->get_field_id( 'redirect-url' ); ?>"><?php _e('Redirect URL (Defaults to current page)', WE_LS_SLUG); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'redirect-url' ); ?>" name="<?php echo $this->get_field_name( 'redirect-url' ); ?>" type="text" value="<?php echo esc_attr( $field_values['redirect-url'] ); ?>">
+			<p><small><?php _e('Specify where the user should be redirected to after completing the form. Note: The URL must be within the site domain.', WE_LS_SLUG); ?></small></p>
+		</p>
 
 		<?php
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight, loss, lose, helper, bmi, body, mass, index, graph, track, stones, kg, table, data, plot, target, history, pounds, responsive, chart, measurements, cm, centimeters, inches, hip, waist, bicep, thigh
 Requires at least: 4.1.0
 Tested up to: 4.7.2
-Stable tag: 4.2.6
+Stable tag: 4.2.7
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -157,6 +157,17 @@ Lots of new features. Three new Pro shortcodes, email notifications and more.
 
 == Changelog ==
 
+= 4.2.7 =
+
+* Improvement: New shortcode for user settings [wlt-user-settings] - Read more: https://weight.yeken.uk/shortcodes/
+* Improvement: New option added to [wlt-chart] "ignore-login-status". If set to true, will display the chart's data in the event the user is not logged in (should be used alongside user-id attribute) - Read more: https://weight.yeken.uk/shortcodes/
+* Improvement: Added "Redirect URL" to Form Widget.
+* Improvement: Optimised speed of user preference lookup (if non sepcified). Previously if the user hadn't specified any user preferences the DB would have be queried for every key lookup. This was due to an empty array not being cached. Rules have changed to store an empty array to save querying DB for each user preference.
+* Improvement: Standardised Hook / Filter names (possible breaking change if you use these). Reade more: https://weight.yeken.uk/hooks-and-filters/
+* Improvement: Added "Neck" measurements.
+* Bug fix: Fixed issue with cache keys for pounds and Kgs conflicting and replacing each other when querying extremes.
+* Bug fix: Ensure both cron jobs are removed on plugin deactivation.
+
 = 4.2.6 =
 
 * Bug fix: Fixed an issue with cache not being cleared properly upon target being set.
@@ -164,7 +175,7 @@ Lots of new features. Three new Pro shortcodes, email notifications and more.
 
 = 4.2.5 =
 
-* Decimal places are now a core feature and no longer just a perk of Pro.
+* Decimal places are now a core feature and no longer just be a perk of Pro.
 
 = 4.2.4 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name: Weight Loss Tracker
  * Description: Allow registered users of your website to track their weight and relevant body measurements. History can be displayed in both tables & charts.
- * Version: 4.2.6
+ * Version: 4.2.7
 
  * Author: YeKen
  * Author URI: https://www.YeKen.uk
@@ -29,7 +29,7 @@ defined('ABSPATH') or die('Jog on!');
 */
 
 define('WS_LS_ABSPATH', plugin_dir_path( __FILE__ ));
-define('WE_LS_CURRENT_VERSION', '4.2.6');
+define('WE_LS_CURRENT_VERSION', '4.2.7');
 
 // -----------------------------------------------------------------------------------------
 // AC: Activate / Deactivate / Uninstall Hooks


### PR DESCRIPTION
* Improvement: New shortcode for user settings [wlt-user-settings] - Read more: https://weight.yeken.uk/shortcodes/
* Improvement: New option added to [wlt-chart] "ignore-login-status". If set to true, will display the chart's data in the event the user is not logged in (should be used alongside user-id attribute) - Read more: https://weight.yeken.uk/shortcodes/
* Improvement: Added "Redirect URL" to Form Widget.
* Improvement: Optimised speed of user preference lookup (if non sepcified). Previously if the user hadn't specified any user preferences the DB would have be queried for every key lookup. This was due to an empty array not being cached. Rules have changed to store an empty array to save querying DB for each user preference.
* Improvement: Standardised Hook / Filter names (possible breaking change if you use these). Reade more: https://weight.yeken.uk/hooks-and-filters/
* Improvement: Added "Neck" measurements.
* Bug fix: Fixed issue with cache keys for pounds and Kgs conflicting and replacing each other when querying extremes.
* Bug fix: Ensure both cron jobs are removed on plugin deactivation.