### PR TITLE
5.0.4

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -88,14 +88,14 @@
 		wp_enqueue_script('jquery-validate-additional',plugins_url( '../js/additional-methods.min.js', __FILE__ ), array('jquery', 'jquery-validate'), WE_LS_CURRENT_VERSION);
 
 		wp_enqueue_script('jquery-ui-datepicker');
-		wp_enqueue_script('wl-ls-js', plugins_url( '../js/ws-ls' . 	$minified . '.js', __FILE__ ), array(), WE_LS_CURRENT_VERSION, true);
-		wp_enqueue_script('wl-ls-js-form', plugins_url( '../js/ws-ls-entry-form.js', __FILE__ ), array(), WE_LS_CURRENT_VERSION, true);
+		wp_enqueue_script('ws-ls-js', plugins_url( '../js/ws-ls' . 	$minified . '.js', __FILE__ ), array(), WE_LS_CURRENT_VERSION, true);
+		wp_enqueue_script('ws-ls-js-form', plugins_url( '../js/ws-ls-entry-form.js', __FILE__ ), array(), WE_LS_CURRENT_VERSION, true);
 
-        wp_enqueue_script('chart-js', WE_LS_CDN_CHART_JS, array( 'jquery', 'wl-ls-js' ), WE_LS_CURRENT_VERSION);
-        wp_enqueue_script('jquery-chart-ws-ls', plugins_url( '../js/ws-ls-chart' . 	$minified . '.js', __FILE__ ), array('chart-js'), WE_LS_CURRENT_VERSION, true);
+        wp_enqueue_script('ws-ls-chart-js', WE_LS_CDN_CHART_JS, array( 'jquery', 'ws-ls-js' ), WE_LS_CURRENT_VERSION);
+        wp_enqueue_script('jquery-chart-ws-ls', plugins_url( '../js/ws-ls-chart' . 	$minified . '.js', __FILE__ ), array('ws-ls-chart-js'), WE_LS_CURRENT_VERSION, true);
 
         // Add localization data for JS
-		wp_localize_script('wl-ls-js', 'ws_ls_config', ws_ls_get_js_config());
+		wp_localize_script('ws-ls-js', 'ws_ls_config', ws_ls_get_js_config());
 
 		// Tabs enabled?
 		if (WE_LS_USE_TABS)	{
@@ -141,8 +141,8 @@
 			if(in_array($_GET['mode'], ['entry', 'user-settings'])) {
 				ws_ls_enqueue_form_dependencies();
 			} else if ('user' == $_GET['mode'] ) {
-                wp_enqueue_script('chart-js', WE_LS_CDN_CHART_JS, array( 'jquery' ), WE_LS_CURRENT_VERSION);
-                wp_enqueue_script('jquery-chart-ws-ls', plugins_url( '../js/ws-ls-chart' . 	$minified . '.js', __FILE__ ), array('chart-js'), WE_LS_CURRENT_VERSION, true);
+                wp_enqueue_script('ws-ls-chart-js', WE_LS_CDN_CHART_JS, array( 'jquery' ), WE_LS_CURRENT_VERSION);
+                wp_enqueue_script('jquery-chart-ws-ls', plugins_url( '../js/ws-ls-chart' . 	$minified . '.js', __FILE__ ), array('ws-ls-chart-js'), WE_LS_CURRENT_VERSION, true);
 				wp_localize_script('jquery-chart-ws-ls', 'ws_ls_config', ws_ls_get_js_config());
 			}
 		}
@@ -161,8 +161,8 @@
 		wp_enqueue_script('jquery-ui-datepicker');
 		wp_enqueue_script('jquery-validate',plugins_url( '../js/jquery.validate.min.js', __FILE__ ), array('jquery'), WE_LS_CURRENT_VERSION);
 		wp_enqueue_script('jquery-validate-additional',plugins_url( '../js/additional-methods.min.js', __FILE__ ), array('jquery', 'jquery-validate'), WE_LS_CURRENT_VERSION);
-		wp_enqueue_script('wl-ls-js', plugins_url( '../js/ws-ls-entry-form' . 	$minified . '.js', __FILE__ ), array(), WE_LS_CURRENT_VERSION, true);
-		wp_localize_script('wl-ls-js', 'ws_ls_config', ws_ls_get_js_config());
+		wp_enqueue_script('ws-ls-js', plugins_url( '../js/ws-ls-entry-form' . 	$minified . '.js', __FILE__ ), array(), WE_LS_CURRENT_VERSION, true);
+		wp_localize_script('ws-ls-js', 'ws_ls_config', ws_ls_get_js_config());
 	}
 
 	function ws_ls_use_minified() {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight, loss, lose, helper, bmi, body, mass, index, graph, track, stones, kg, table, data, plot, target, history, pounds, responsive, chart, measurements, cm, centimeters, inches, hip, waist, bicep, thigh
 Requires at least: 4.4.0
 Tested up to: 4.8
-Stable tag: 5.0.3
+Stable tag: 5.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate Link: https://www.paypal.me/yeken
@@ -159,6 +159,10 @@ Yes. In WordPress Admin goto Settings > Weight Loss Tracker and change the setti
 5.0! Now view and interact with your user's data like never before.
 
 == Changelog ==
+
+= 5.0.4 =
+
+* Bug fix: Fixed missing charts doe to clashes with other plugins. JS enqueue issue where other plugins were using Chart.js (myCred in this example) with the same enqueue slug.
 
 = 5.0.3 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name: Weight Loss Tracker
  * Description: Allow registered users of your website to track their weight and relevant body measurements. History can be displayed in both tables & charts.
- * Version: 5.0.3
+ * Version: 5.0.4
  * Author: YeKen
  * Author URI: https://www.YeKen.uk
  * License: GPL2
@@ -28,7 +28,7 @@ defined('ABSPATH') or die('Jog on!');
 */
 
 define('WS_LS_ABSPATH', plugin_dir_path( __FILE__ ));
-define('WE_LS_CURRENT_VERSION', '5.0.3');
+define('WE_LS_CURRENT_VERSION', '5.0.4');
 define('WE_LS_DB_VERSION', '5.0.0');
 
 // -----------------------------------------------------------------------------------------


### PR DESCRIPTION
= 5.0.4 =

* Bug fix: Fixed missing charts doe to clashes with other plugins. JS enqueue issue where other plugins were using Chart.js (myCred in this example) with the same enqueue slug.