### PR TITLE
5.1.5

### DIFF
--- a/includes/activate.php
+++ b/includes/activate.php
@@ -116,6 +116,9 @@
 			ws_ls_create_mysql_tables();
 			ws_ls_activate();
             ws_ls_stats_clear_last_updated_date(); // This will force all stat entries to be recreated.
+
+            // Check the license is still valid
+            ws_ls_licences_cron();
  		}
 	}
 	add_action('admin_init', 'ws_ls_upgrade');

--- a/includes/core.php
+++ b/includes/core.php
@@ -247,7 +247,10 @@ function ws_ls_display_weight_form($target_form = false, $class_name = false, $u
     // Make sure they are logged in
     if (!is_user_logged_in())	{
         if ($hide_login_message_if_needed) {
-            return '<blockquote class="ws-ls-blockquote"><p>' .	__('You need to be logged in to record your weight.', WE_LS_SLUG) . ' <a href="' . wp_login_url(get_permalink()) . '">' . __('Login now', WE_LS_SLUG) . '</a>.</p></blockquote>';
+
+            $prompt = ( true === $target_form ) ? __('You need to be logged in to set your target.', WE_LS_SLUG) : __('You need to be logged in to record your weight.', WE_LS_SLUG);
+
+            return '<blockquote class="ws-ls-blockquote"><p>' .	$prompt . ' <a href="' . wp_login_url(get_permalink()) . '">' . __('Login now', WE_LS_SLUG) . '</a>.</p></blockquote>';
         } else {
             return;
         }

--- a/includes/core.php
+++ b/includes/core.php
@@ -357,7 +357,7 @@ function ws_ls_display_weight_form($target_form = false, $class_name = false, $u
 
 	    // Include
 	    if(!$target_form && $measurements_form_enabled) {
-	        $html_output .= sprintf('<br /><h3 class="ws_ls_title">%s</h3>', __('Add measurements', WE_LS_SLUG));
+	        $html_output .= sprintf('<br /><h3 class="ws_ls_title">%s (%s)</h3>', __('Add measurements', WE_LS_SLUG), (WE_LS_MEASUREMENTS_MANDATORY) ? __('Mandatory', WE_LS_SLUG) : __('Optional', WE_LS_SLUG));
 	        $html_output .= ws_ls_load_measurement_form($existing_data);
 	    }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -552,6 +552,10 @@ function ws_ls_querystring_value($key, $force_to_int = false, $default = false) 
 
 function ws_ls_get_url($base_64_encode = false) {
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+
+	// Wee hack, replace removedata querystring value
+	$current_url = str_replace('removedata', 'removed', $current_url);
+
 	return (true === $base_64_encode) ? base64_encode($current_url) : $current_url;
 }
 

--- a/pro-features/init.php
+++ b/pro-features/init.php
@@ -81,6 +81,7 @@ function ws_ls_register_pro_shortcodes(){
 	add_shortcode( 'wlt-table', 'ws_ls_shortcode_table' );
 	add_shortcode( 'weight-loss-tracker-most-recent-bmi', 'ws_ls_get_user_bmi' );
 	add_shortcode( 'wlt-recent-bmi', 'ws_ls_get_user_bmi' );
+	add_shortcode( 'wlt-bmi', 'ws_ls_get_user_bmi' );
 	add_shortcode( 'weight-loss-tracker-total-lost', 'ws_ls_shortcode_stats_total_lost' );
 	add_shortcode( 'wlt-total-lost', 'ws_ls_shortcode_stats_total_lost' );
 	add_shortcode( 'weight-loss-tracker-league-table', 'ws_ls_shortcode_stats_league_total' );

--- a/pro-features/shortcode-if.php
+++ b/pro-features/shortcode-if.php
@@ -7,9 +7,10 @@ defined('ABSPATH') or die("Jog on");
  *
  * @param $user_defined_arguments
  * @param null $content - content between WP tags
+ * @param $level - used to determine level of IF nesting
  * @return string
  */
-function ws_ls_shortcode_if($user_defined_arguments, $content = null) {
+function ws_ls_shortcode_if($user_defined_arguments, $content = null, $level = 0) {
 
 	// Check if we have content between opening and closing [wlt-if] tags, if we don't then nothing to render so why bother proceeding?
 	if(true === empty($content)) {
@@ -26,6 +27,7 @@ function ws_ls_shortcode_if($user_defined_arguments, $content = null) {
 	$arguments['user-id'] = ws_ls_force_numeric_argument($arguments['user-id'], get_current_user_id());
 	$arguments['operator'] = (true === in_array($arguments['operator'], ['exists', 'not-exists'])) ? $arguments['operator'] : 'exists';
 	$arguments['field'] = (true === empty($arguments['field'])) ? 'weight' : $arguments['field'];
+	$level = ws_ls_force_numeric_argument($level, '');
 
 	// Remove Pro Plus fields if they don't have a license
 	if( false === WS_LS_IS_PRO_PLUS && true === in_array($arguments['field'], ['bmr'])) {
@@ -34,12 +36,14 @@ function ws_ls_shortcode_if($user_defined_arguments, $content = null) {
 
 	$else_content = '';
 
+	$else_tag = ($level > 0) ? '[else-' . $level . ']' : '[else]';
+
 	// Is there an [else] within the content? If so, split the content into true condition and else.
-	$else_location = stripos($content, '[else]');
+	$else_location = stripos($content, $else_tag);
 
 	if(false !== $else_location) {
 
-		$else_content = substr($content, $else_location + 6);
+		$else_content = substr($content, $else_location + strlen($else_tag));
 
 		// Strip out [else] content from true condition
 		$content = substr($content, 0, $else_location);
@@ -132,3 +136,39 @@ function ws_ls_shortcode_if_value_exist($user_id, $fields) {
 function ws_ls_shortcode_if_valid_field_name($field) {
     return (true === in_array($field, ['weight', 'target', 'bmr', 'height', 'gender', 'activity_level', 'dob', 'is-logged-in']));
 }
+
+/**
+ * Shortcode to allow nesting of [wlt-if]. This is for [wlt-if-1]
+ *
+ * @param $user_defined_arguments
+ * @param null $content
+ * @return string
+ */
+function ws_ls_shortcode_if_level_one($user_defined_arguments, $content = null) {
+	return ws_ls_shortcode_if($user_defined_arguments, $content, 1);
+}
+add_shortcode( 'wlt-if-1', 'ws_ls_shortcode_if_level_one' );
+
+/**
+ * Shortcode to allow nesting of [wlt-if]. This is for [wlt-if-2]
+ *
+ * @param $user_defined_arguments
+ * @param null $content
+ * @return string
+ */
+function ws_ls_shortcode_if_level_two($user_defined_arguments, $content = null) {
+	return ws_ls_shortcode_if($user_defined_arguments, $content, 2);
+}
+add_shortcode( 'wlt-if-2', 'ws_ls_shortcode_if_level_two' );
+
+/**
+ * Shortcode to allow nesting of [wlt-if]. This is for [wlt-if-3]
+ *
+ * @param $user_defined_arguments
+ * @param null $content
+ * @return string
+ */
+function ws_ls_shortcode_if_level_three($user_defined_arguments, $content = null) {
+	return ws_ls_shortcode_if($user_defined_arguments, $content, 3);
+}
+add_shortcode( 'wlt-if-3', 'ws_ls_shortcode_if_level_three' );

--- a/pro-features/shortcode-progress-bar.php
+++ b/pro-features/shortcode-progress-bar.php
@@ -114,7 +114,7 @@ function ws_ls_shortcode_progress_bar($user_defined_arguments) {
 				return ws_ls_shortcode_progress_bar_render($arguments);
 
 			} else if ($display_errors) {
-				return __('Please enter add a weight entry to see your progress.', WE_LS_SLUG);
+				return __('Please add a weight entry to see your progress.', WE_LS_SLUG);
 			}
 
 		} else if ($display_errors) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight, loss, lose, helper, bmi, body, mass, index, graph, track, stones, kg, table, data, plot, target, history, pounds, responsive, chart, measurements, cm, centimeters, inches, hip, waist, bicep, thigh
 Requires at least: 4.4.0
 Tested up to: 4.8
-Stable tag: 5.1.4
+Stable tag: 5.1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate Link: https://www.paypal.me/yeken
@@ -130,6 +130,12 @@ Yes. Only recommended if you first installed the plugin at version 1.6 or greate
 5.1! Now support for BMR, BMI, Calorie intake and Macronutrient Calculator.
 
 == Changelog ==
+
+= 5.1.5 =
+
+
+
+    * Improvement: Added a license check to be performed on software update.
 
 = 5.1.4 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ Yes. Only recommended if you first installed the plugin at version 1.6 or greate
 
 = 5.1.5 =
 
+    * Improvement: [wlt-if] field now supports one or more fields (creating an AND statement). Fields can be specified in a comma delimited list. - Read more: https://weight.yeken.uk/shortcodes/
     * Improvement: Prompt to login text when [wlt-form] is in target mode has been modified to remove reference to weight entry.
     * Improvement: Added additional text to display whether the measurements are optional or mandatory.
     * Improvement: Added a license check to be performed on software update.

--- a/readme.txt
+++ b/readme.txt
@@ -134,8 +134,9 @@ Yes. Only recommended if you first installed the plugin at version 1.6 or greate
 = 5.1.5 =
 
 
-
+    * Improvement: Added additional text to display whether the measurements are optional or mandatory.
     * Improvement: Added a license check to be performed on software update.
+    * Bug fix: Fixed a typo in a Progress Bar error message.
 
 = 5.1.4 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,7 +133,7 @@ Yes. Only recommended if you first installed the plugin at version 1.6 or greate
 
 = 5.1.5 =
 
-
+    * Improvement: Prompt to login text when [wlt-form] is in target mode has been modified to remove reference to weight entry.
     * Improvement: Added additional text to display whether the measurements are optional or mandatory.
     * Improvement: Added a license check to be performed on software update.
     * Bug fix: Fixed a typo in a Progress Bar error message.

--- a/readme.txt
+++ b/readme.txt
@@ -133,11 +133,14 @@ Yes. Only recommended if you first installed the plugin at version 1.6 or greate
 
 = 5.1.5 =
 
+	* Improvement: [wlt-if] can now be nested. You can nest [wlt-if] statements upto three levels deep. - Read more: https://weight.yeken.uk/shortcodes/
     * Improvement: [wlt-if] field now supports one or more fields (creating an AND statement). Fields can be specified in a comma delimited list. - Read more: https://weight.yeken.uk/shortcodes/
     * Improvement: Prompt to login text when [wlt-form] is in target mode has been modified to remove reference to weight entry.
     * Improvement: Added additional text to display whether the measurements are optional or mandatory.
     * Improvement: Added a license check to be performed on software update.
+    * Improvement: Added [wlt-bmi] - a shorter name for [wlt-recent-bmi].- Read more: https://weight.yeken.uk/shortcodes/
     * Bug fix: Fixed a typo in a Progress Bar error message.
+	* Bug fix: Removed "Delete user data" command from redirect querystring if previously specified.
 
 = 5.1.4 =
 

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -28,8 +28,8 @@ defined('ABSPATH') or die('Jog on!');
 */
 
 define('WS_LS_ABSPATH', plugin_dir_path( __FILE__ ));
-define('WE_LS_CURRENT_VERSION', '5.1.4');
-define('WE_LS_DB_VERSION', '5.1.4');
+define('WE_LS_CURRENT_VERSION', '5.1.5');
+define('WE_LS_DB_VERSION', '5.1.5');
 
 // -----------------------------------------------------------------------------------------
 // AC: Activate / Deactivate / Uninstall Hooks


### PR DESCRIPTION
* Improvement: [wlt-if] can now be nested. You can nest [wlt-if] statements upto three levels deep. - Read more: https://weight.yeken.uk/shortcodes/
* Improvement: [wlt-if] field now supports one or more fields (creating an AND statement). Fields can be specified in a comma delimited list. - Read more: https://weight.yeken.uk/shortcodes/
* Improvement: Prompt to login text when [wlt-form] is in target mode has been modified to remove reference to weight entry.
* Improvement: Added additional text to display whether the measurements are optional or mandatory.
* Improvement: Added a license check to be performed on software update.
* Improvement: Added [wlt-bmi] - a shorter name for [wlt-recent-bmi].- Read more: https://weight.yeken.uk/shortcodes/
* Bug fix: Fixed a typo in a Progress Bar error message.
* Bug fix: Removed "Delete user data" command from redirect querystring if previously specified.