### PR TITLE
5.2.16

### DIFF
--- a/includes/converters.php
+++ b/includes/converters.php
@@ -47,7 +47,7 @@ function ws_ls_to_stone_pounds($kg)
 	$weight = array ("stones" => 0, "pounds" => 0);
     $totalPounds = Round($kg * 2.20462, 3);
     $weight["stones"] = $totalPounds < 0 ? -1 * floor(-1 * $totalPounds / 14) : floor($totalPounds / 14);
-    $weight["pounds"] = Round(fmod($totalPounds, 14), 1);
+    $weight["pounds"] = Round(fmod($totalPounds, 14), 2);
     return $weight;
 }
 function ws_ls_round_decimals($value)

--- a/includes/core.php
+++ b/includes/core.php
@@ -366,7 +366,7 @@ function ws_ls_display_weight_form($target_form = false, $class_name = false, $u
 	{
 		if (ws_ls_get_config('WE_LS_DATA_UNITS') == 'stones_pounds') {
 			$html_output .= '<input  type="number"  tabindex="' . ws_ls_get_next_tab_index() . '" step="any" min="0" name="we-ls-weight-stones" id="we-ls-weight-stones" value="' . ws_ls_get_existing_value($existing_data, 'stones') . '" placeholder="' . __('Stones', WE_LS_SLUG) . '" size="11" >';
-			$html_output .= '<input  type="number" tabindex="' . ws_ls_get_next_tab_index() . '" step="any" min="0" max="13" name="we-ls-weight-pounds" id="we-ls-weight-pounds" value="' . ws_ls_get_existing_value($existing_data, 'pounds') . '" placeholder="' . __('Pounds', WE_LS_SLUG) . '" size="11"  >';
+			$html_output .= '<input  type="number" tabindex="' . ws_ls_get_next_tab_index() . '" step="any" min="0" max="13.99" name="we-ls-weight-pounds" id="we-ls-weight-pounds" value="' . ws_ls_get_existing_value($existing_data, 'pounds') . '" placeholder="' . __('Pounds', WE_LS_SLUG) . '" size="11"  >';
 		}
 		else {
 			$html_output .= '<input  type="number" tabindex="' . ws_ls_get_next_tab_index() . '" step="any" min="1" name="we-ls-weight-pounds" id="we-ls-weight-pounds" value="' . ws_ls_get_existing_value($existing_data, 'only_pounds') . '" placeholder="' . __('Pounds', WE_LS_SLUG) . '" size="11"  >';

--- a/includes/shortcode-weight-loss-tracker.php
+++ b/includes/shortcode-weight-loss-tracker.php
@@ -9,17 +9,6 @@
 			global $save_response;
 			global $ws_ls_wlt_already_placed;
 
-			if ( true === $ws_ls_wlt_already_placed ) {
-			   return '<p>' . __('This shortcode can only be placed once on a page / post.', WE_LS_SLUG) . '</p>';
-            }
-
-			ws_ls_enqueue_files();
-
-			// Display error if user not logged in
-			if (!is_user_logged_in())	{
-				return ws_ls_display_blockquote(__('You need to be logged in to record your weight.', WE_LS_SLUG) , '', false, true);
-			}
-
             $shortcode_arguments = shortcode_atts(
             array(
                 'min-chart-points' => 2,					// Minimum number of data entries before chart is shown
@@ -32,7 +21,8 @@
                 'hide-tab-advanced' => false,               // Hide Advanced tab (macroN, calories, etc)
                 'hide-advanced-narrative' => false,         // Hide text describing BMR, MarcoN, etc
                 'disable-advanced-tables' => false,         // Disable advanced data tables.
-                'disable-tabs' => false                     // Disable using tabs.
+                'disable-tabs' => false,                    // Disable using tabs.
+				'disable-second-check' => false				// Disable check to see if [wlt] placed more than once
                ), $user_defined_arguments );
 
 			// Validate arguments
@@ -47,6 +37,18 @@
             $shortcode_arguments['hide-advanced-narrative'] = ws_ls_force_bool_argument($shortcode_arguments['hide-advanced-narrative']);
             $shortcode_arguments['disable-advanced-tables'] = ws_ls_force_bool_argument($shortcode_arguments['disable-advanced-tables']);
             $shortcode_arguments['disable-tabs'] = ws_ls_force_bool_argument($shortcode_arguments['disable-tabs']);
+			$shortcode_arguments['disable-second-check'] = ws_ls_force_bool_argument($shortcode_arguments['disable-second-check']);
+
+			if ( true === $ws_ls_wlt_already_placed && false === $shortcode_arguments['disable-second-check'] ) {
+				return '<p>' . __('This shortcode can only be placed once on a page / post.', WE_LS_SLUG) . '</p>';
+			}
+
+			ws_ls_enqueue_files();
+
+			// Display error if user not logged in
+			if (!is_user_logged_in())	{
+				return ws_ls_display_blockquote(__('You need to be logged in to record your weight.', WE_LS_SLUG) , '', false, true);
+			}
 
             $user_id = get_current_user_id();
             $use_tabs = (false === $shortcode_arguments['disable-tabs']);

--- a/pro-features/footable.php
+++ b/pro-features/footable.php
@@ -111,10 +111,10 @@ function ws_ls_data_table_get_rows($user_id = false, $max_entries = false, $smal
 
 					if ($data['kg'] > $previous_user_weight[$data['user_id']]) {
 						$gain_class = 'gain';
-						$gain_loss = ws_ls_convert_kg_into_relevant_weight_String($data['kg'] - $previous_user_weight[$data['user_id']], false, $convert_weight_format);
+						$gain_loss = ws_ls_convert_kg_into_relevant_weight_String($data['kg'] - $previous_user_weight[$data['user_id']], true, $convert_weight_format);
 					} elseif ($data['kg'] < $previous_user_weight[$data['user_id']]) {
 						$gain_class = 'loss';
-						$gain_loss = ws_ls_convert_kg_into_relevant_weight_String($data['kg'] - $previous_user_weight[$data['user_id']], false, $convert_weight_format);
+						$gain_loss = ws_ls_convert_kg_into_relevant_weight_String($data['kg'] - $previous_user_weight[$data['user_id']], true, $convert_weight_format);
 					} elseif ($data['kg'] == $previous_user_weight[$data['user_id']]) {
 						$gain_class = 'same';
 					}

--- a/pro-features/plus/harris.benedict.php
+++ b/pro-features/plus/harris.benedict.php
@@ -218,7 +218,7 @@
 		return ws_ls_harris_benedict_render_table($arguments['user-id'], $arguments['error-message'], $arguments['css-class']);
 	}
 	add_shortcode( 'wlt-calories-table', 'ws_ls_shortcode_harris_benedict_table' );
-
+	
     /**
      *
      * Depending on the user's gender, display the calorie cap information

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: aliakro
 Tags: weight, loss, lose, helper, bmi, body, mass, index, graph, track, stones, kg, table, data, plot, target, history, pounds, responsive, chart, measurements, cm, centimeters, inches, hip, waist, bicep, thigh
 Requires at least: 4.4.0
 Tested up to: 4.8.2
-Stable tag: 5.2.15
+Stable tag: 5.2.16
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate Link: https://www.paypal.me/yeken
@@ -14,7 +14,7 @@ Allow registered users of your website to track their weight and relevant body m
 
 = Documentation =
 
-Use our free site for tracking your weight which shows of some of the plugin's feature: [TrackYourWeight.co.uk - Demo Site](https://www.trackyourweight.co.uk "TrackYourWeight.co.uk")
+Use our free site for tracking your weight which shows off some of the plugin's feature: [TrackYourWeight.co.uk - Demo Site](https://www.trackyourweight.co.uk "TrackYourWeight.co.uk")
 
 = Core Features =
 
@@ -137,9 +137,15 @@ Yes. Only recommended if you first installed the plugin at version 1.6 or greate
 
 == Changelog ==
 
+= 5.2.16 =
+
+* Improvement: Added additional argument for [wlt] shortcode that disables the check to see if [wlt] has already been placed on the page. Some users (and clashing plugins) were causing it to fail.
+* Bug fix: Allow decimal entries for pounds (when in stones and pounds).
+* Bug fix: When display comparison values, a rounding to one decimal place was causing the difference values to be slightly out. This has been changed to two decimals.
+
 = 5.2.15 =
 
-* Bug fix: When "Server Default" was selected it would not allow any photo uploads to happen. This has been fixed.
+* Bug fix: When "Server Default" was selected for Photo uploads it would not allow any photo uploads to happen. This has been fixed.
 * Added helper function ws_ls_if() for simplified IF checks.
 
 = 5.2.14 =

--- a/weight-loss-tracker.php
+++ b/weight-loss-tracker.php
@@ -5,7 +5,7 @@ defined('ABSPATH') or die('Jog on!');
 /**
  * Plugin Name: Weight Loss Tracker
  * Description: Allow registered users of your website to track their weight and relevant body measurements. History can be displayed in both tables & charts.
- * Version: 5.2.15
+ * Version: 5.2.16
  * Author: YeKen
  * Author URI: https://www.YeKen.uk
  * License: GPL2
@@ -28,8 +28,8 @@ defined('ABSPATH') or die('Jog on!');
 */
 
 define('WS_LS_ABSPATH', plugin_dir_path( __FILE__ ));
-define('WE_LS_CURRENT_VERSION', '5.2.15');
-define('WE_LS_DB_VERSION', '5.2.15');
+define('WE_LS_CURRENT_VERSION', '5.2.16');
+define('WE_LS_DB_VERSION', '5.2.16');
 
 // -----------------------------------------------------------------------------------------
 // AC: Activate / Deactivate / Uninstall Hooks


### PR DESCRIPTION
* Improvement: Added additional argument for [wlt] shortcode that disables the check to see if [wlt] has already been placed on the page. Some users (and clashing plugins) were causing it to fail.
* Bug fix: Allow decimal entries for pounds (when in stones and pounds).
* Bug fix: When display comparison values, a rounding to one decimal place was causing the difference values to be slightly out. This has been changed to two decimals.
